### PR TITLE
set min/max Value  for outdoor weather temperature sensor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1762,6 +1762,11 @@ function TadoWeather(log, config){
     this.TemperatureSensor = new Service.TemperatureSensor(this.name);
 
     this.TemperatureSensor.getCharacteristic(Characteristic.CurrentTemperature)
+        .setProps({
+           maxValue: 100,
+           minValue: -100,
+           minStep: 1
+        })
         .on('get', this.getOutsideTemperature.bind(this));
 
     this.SolarSensor = new Service.Lightbulb("Solar Intensity");


### PR DESCRIPTION
set min/max Value for outdoor weather temperature sensor to show correct value in Apple Home.

I had problem with showing the correct value (shows only 0 degrees)  in Apple Home (cause of celsius) , so setting min/max Value will fix this problem