### PR TITLE
URIEncode the username as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function TadoACplatform(log, config, api) {
     this.log = log
     this.config = config
     this.name = config['name'] || "Tado AC"
-    this.username = config['username']
+    this.username = encodeURIComponent(config['username'])
     this.password = encodeURIComponent(config['password'])
     this.homeId = config['homeID']
     this.tadoMode = config['tadoMode'] || "MANUAL"


### PR DESCRIPTION
As the username is sent as url parameter, using any special char (such as `+`) inside the username would break getting a token.

This then leads to the situation where you can see the current settings (and even polling works fine), but no changes can be made (as no token is ever fetched successfully).

With this change, everything gets back to normal.