### PR TITLE
Feature: Add Eve History support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ _________________________________________
         "manualControlSwitch": true,
         "disableHumiditySensor": false,
         "extraHumiditySensor": ["Living Room", 3],
-        "disableFan": true
+        "disableFan": true,
+        "historyStorage": "fs"
     }
 ]
 ```
@@ -93,6 +94,7 @@ _________________________________________
 | `disableFan`       |  When set to `true`, it will disable the fan accessory   |             |  `false` |   Boolean / Array*  |
 | `extraHumiditySensor` ***new      |  When set to `true`, it will add extra separate humidity sensor.  |             |  `false` |   Boolean / Array*  |
 | `forceThermostat` ***new      |  When set to `true`, it will force Homebridge to create Thermostat accessory instead of the HeaterCooler(AC)  |             |  `false` |   Boolean / Array*  |
+| `historyStorage` ***new          |  When set to `fs`, the `fakegato-history` library will log every datapoint to a file  |             |  - |   String*  |
 
 
 #### * Config Array - ####
@@ -169,7 +171,8 @@ If not set otherwise, the system will check for the status every 10 seconds.
 
 **"Anyone"** Sensor will be added automatically to easily automate actions when the first person arrives home or the last person leaves. this is a better alternative to Home App Arrive/Leave automations since this will not require approval for triggering automation. to remove this accessory, set `anyoneSensor` to false
 
-
+### History
+If you install the optinal dependency `fakegato-history`, then temperature (tado and outside weather if enabled) and humidity (only tado) will be stored and made available via homekit using Elgato Eve compatible services and characteristics. In combination with the Eve App you can then access the historic values on your iOS device.
 
 
 ## Updates

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-let Service, Characteristic, tadoHelpers
+let Service, Characteristic, Accessory, tadoHelpers
 const async = require("async")
 const tadoApi = require("./lib/tadoApi.js")
 const storage = require('node-persist')

--- a/lib/tadoHelpers.js
+++ b/lib/tadoHelpers.js
@@ -446,6 +446,10 @@ module.exports = (tadoApi, storage, Characteristic) => {
                     this.ManualSwitchService.getCharacteristic(Characteristic.On).updateValue(1)
                 }
             }
+
+            // log new state
+            this.loggingService && this.loggingService.addEntry({ time: Math.floor((new Date()).getTime()/1000), temp: insideTemperature.celsius, humidity: state.sensorDataPoints.humidity.percentage })
+
             this.lastState = state
         },
 
@@ -603,6 +607,9 @@ module.exports = (tadoApi, storage, Characteristic) => {
                             self.TemperatureSensor.getCharacteristic(Characteristic.CurrentTemperature).updateValue(self.lastState.temp)
                             self.SolarSensor.getCharacteristic(Characteristic.Brightness).updateValue(self.lastState.solar)
                             self.SolarSensor.getCharacteristic(Characteristic.On).updateValue(!!self.lastState.solar)
+
+                            // log new state
+                            self.loggingService && self.loggingService.addEntry({ time: Math.floor((new Date()).getTime()/1000), temp: self.lastState.temp, humidity: self.lastState.solar })
                         } else {
                             if (self.debug) self.log('Sending', weatherCallbacks.callbacks.length, 'callbacks to', self.name)
                             weatherCallbacks.callbacks.forEach(callback => {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "node-persist": "0.0.8",
     "async": "*"
   },
+  "optionalDependencies": {
+    "fakegato-history": "^0.5.3"
+  },
   "bugs": {
     "url": "https://github.com/nitaybz/homebridge-tado-ac/issues"
   },


### PR DESCRIPTION
This PR will enable storing history values and expose them using the `fakegato-history` plugin.
Using the Eve app you can then access the old values on iOS:
![image](https://user-images.githubusercontent.com/1755213/61938259-f1e55200-af90-11e9-8d0d-26682d07e458.png)

After installing the updated package and the dependency, it will take at least 10 minutes before the Eve App will show log entries. This is due to the way the library works (it runs an internal timer of around 10min and only produces entries when the timer runs)

**Note**: This is set to be an `optionalDependency` to keep the package slim if one does not want to use the history - thus every time it's used, checks have been added to make sure to work without the library installed.