### PR TITLE
Don't reverse the stored fan levels every time fanLevelToHK() is called.

### DIFF
--- a/tado/unified.js
+++ b/tado/unified.js
@@ -136,8 +136,8 @@ module.exports = {
 		state.swing = (state.mode === 'OFF' || !modeCapabilities.swing || !device.state.setting.swing || device.state.setting.swing === 'OFF') ?
 			'SWING_DISABLED' : 'SWING_ENABLED'
 
-		state.fanSpeed = (state.mode === 'OFF' || !modeCapabilities.fanSpeeds || !device.state.setting.fanSpeed) ? 
-			0 : fanLevelToHK(device.state.setting.fanSpeed, modeCapabilities.fanSpeeds.reverse())
+		state.fanSpeed = (state.mode === 'OFF' || !modeCapabilities.fanSpeeds || !device.state.setting.fanSpeed) ?
+			0 : fanLevelToHK(device.state.setting.fanSpeed, modeCapabilities.fanSpeeds)
 
 
 		return state


### PR DESCRIPTION
The fanspeed capabilities from Tado come back in order: Auto, High, Middle, Low. Current code already reversed the array from Tado in unified.capabilities, but was also reversing in unified.acState. This meant that in translating the percentage-based value from HomeKit, the code applied `.reverse()` each time -- which mutates the array in place.

This PR simply removes the call to fanSpeeds.reverse() that was happening each time acState() was called.

This extract of the log shows the problem this PR fixes. Rotation Speed 16% should translate to 'LOW', but instead sends 'HIGH' every second time:

```
[07/02/2021, 2:50:22 pm] [TadoAC] Air Conditioning AC -> Setting AC state Active: true
[07/02/2021, 2:50:22 pm] [TadoAC] Air Conditioning AC -> Setting Mode to COOL
[07/02/2021, 2:50:22 pm] [TadoAC] Air Conditioning AC -> Setting AC Rotation Speed: 16%
[07/02/2021, 2:50:22 pm] [TadoAC] Air Conditioning AC -> Setting Mode to COOL
[07/02/2021, 2:50:22 pm] [TadoAC] Air Conditioning AC  -> Setting New State:
[07/02/2021, 2:50:22 pm] [TadoAC] {
"termination": {
"type": "TADO_MODE"
},
"setting": {
"type": "AIR_CONDITIONING",
"power": "ON",
"mode": "COOL",
"temperature": {
"fahrenheit": 68,
"celsius": 20
},
"swing": "OFF",
"fanSpeed": "HIGH"
}
}
[07/02/2021, 2:50:22 pm] [TadoAC] Creating PUT request to tado° API --->
[07/02/2021, 2:50:22 pm] [TadoAC] https://my.tado.com/api/v2/homes/652045/zones/1/overlay
[07/02/2021, 2:50:22 pm] [TadoAC] data: {"termination":{"type":"TADO_MODE"},"setting":{"type":"AIR_CONDITIONING","power":"ON","mode":"COOL","temperature":{"fahrenheit":68,"celsius":20},"swing":"OFF","fanSpeed":"HIGH"}}
```
