### PR TITLE
Tado api update

### DIFF
--- a/tado/unified.js
+++ b/tado/unified.js
@@ -110,7 +110,7 @@ module.exports = {
 			}
 
 			// set swing
-			if (modeCapabilities.swings) {
+			if (modeCapabilities.verticalSwing) {
 				capabilities[mode].swing = true
 			}
 
@@ -196,14 +196,11 @@ module.exports = {
 		
 		overlay.setting.mode = state.mode
 
-		// add temperatures to heat and cool
-		if (['HEAT', 'COOL'].includes(state.mode)) {
-			if (!state.targetTemperature)
-				state.targetTemperature = 25
-			overlay.setting.temperature = {
-				fahrenheit: toFahrenheit(state.targetTemperature),
-				celsius: state.targetTemperature
-			}
+		if (!state.targetTemperature)
+			state.targetTemperature = 25
+		overlay.setting.temperature = {
+			fahrenheit: toFahrenheit(state.targetTemperature),
+			celsius: state.targetTemperature
 		}
 		
 		if ('swing' in device.capabilities[state.mode])


### PR DESCRIPTION
According to the new tado API - temperature must be set within any mode (including AUTO). 
![image](https://github.com/nitaybz/homebridge-tado-ac/assets/32637427/93403d63-a3a8-4e64-84f5-0ca84580fec8)

`swings` property also renamed to `verticalSwing`
![image](https://github.com/nitaybz/homebridge-tado-ac/assets/32637427/5e5c4f60-1d9e-447b-bc53-33b74d54222d)
